### PR TITLE
Fix incorrect PDF tools path

### DIFF
--- a/app/data/toolsList.ts
+++ b/app/data/toolsList.ts
@@ -2,7 +2,7 @@ export const tools = [
     {
       name: "PDF Tools",
       description: "Merge, split, compress, and edit PDFs with ease.",
-      path: "tools/pdf",
+      path: "/tools/pdf",
     },
     {
       name: "AI Tools",


### PR DESCRIPTION
## Summary
- fix Tools PDF path to prevent nested routes

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844ee7154788325b554ce951b690465