### PR TITLE
Fix Next.js lint errors in PDF pages

### DIFF
--- a/app/tools/pdf/merge/page.tsx
+++ b/app/tools/pdf/merge/page.tsx
@@ -9,6 +9,7 @@ import {
   PointerSensor,
   useSensor,
   useSensors,
+  DragEndEvent,
 } from "@dnd-kit/core";
 import {
   arrayMove,
@@ -97,7 +98,7 @@ export default function MergePDFPage() {
     URL.revokeObjectURL(url);
   };
 
-  const handleDragEnd = (event: any) => {
+  const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
     if (!over || active.id === over.id) return;
 
@@ -155,8 +156,9 @@ export default function MergePDFPage() {
                       onRemove={() => {
                         setFiles((prev) => prev.filter((f) => f.id !== file.id));
                         setThumbnails((prev) => {
-                          const { [file.id]: _, ...rest } = prev;
-                          return rest;
+                          const updated = { ...prev };
+                          delete updated[file.id];
+                          return updated;
                         });
                       }}
                     />

--- a/app/tools/pdf/split/page.tsx
+++ b/app/tools/pdf/split/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { PDFDocument } from "pdf-lib";
 import * as pdfjsLib from "pdfjs-dist";
 import Link from "next/link";


### PR DESCRIPTION
## Summary
- type `handleDragEnd` and import `DragEndEvent`
- clean up thumbnail removal logic
- remove unused `useEffect` import

## Testing
- `npm run lint` *(fails: next not found)*
- `NEXT_DISABLE_ESLINT=1 npx --no-install next build` *(fails: 403 Forbidden when fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_6844f9104be88325b3079cdea407b77d