### PR TITLE
Fix logo path for GitHub Pages

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -35,11 +35,12 @@ export default function RootLayout({
           <header className="p-6 border-b border-gray-800 flex justify-between items-center max-w-7xl mx-auto">
             <Link href="/" className="flex items-center space-x-2">
               <Image
-                src="/dmz.png" // make sure this path matches your logo in /public
+                src={`${process.env.NEXT_PUBLIC_BASE_PATH || ''}/dmz.png`}
                 alt="Digital Meta Zone Logo"
                 width={170}
                 height={170}
                 className="object-contain"
+                priority
               />
               {/* <span className="text-xl sm:text-2xl font-semibold">
                 Digital Meta Zone

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  basePath: process.env.NEXT_PUBLIC_BASE_PATH || "",
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- set `basePath` in `next.config.ts`
- load logo using `NEXT_PUBLIC_BASE_PATH`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684558d007288325b3f51b8bf2ca3d44