### PR TITLE
Fix logo path for basePath

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -35,7 +35,7 @@ export default function RootLayout({
           <header className="p-6 border-b border-gray-800 flex justify-between items-center max-w-7xl mx-auto">
             <Link href="/" className="flex items-center space-x-2">
               <Image
-                src={`${process.env.NEXT_PUBLIC_BASE_PATH || ''}/dmz.png`}
+                src="/dmz.png"
                 alt="Digital Meta Zone Logo"
                 width={170}
                 height={170}


### PR DESCRIPTION
## Summary
- fix the header logo to rely on Next.js `basePath` handling

## Testing
- `npm run build` *(fails: `next` not found)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68455ab476a48325a4ddb118eb8c3fbf