### PR TITLE
Fix ESLint issues

### DIFF
--- a/app/tools/pdf/merge/page.tsx
+++ b/app/tools/pdf/merge/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { PDFDocument } from "pdf-lib";
 import Link from "next/link";
+import Image from "next/image";
 import {
   DndContext,
   closestCenter,
@@ -247,9 +248,11 @@ function SortableThumbnail({
       className="relative bg-gray-800 p-2 rounded-lg border border-gray-700 cursor-move"
     >
       {thumbnail && (
-        <img
+        <Image
           src={thumbnail}
           alt="PDF Thumbnail"
+          width={128}
+          height={128}
           className="w-full h-32 object-cover rounded"
         />
       )}

--- a/app/tools/pdf/pdf-to-word/page.tsx
+++ b/app/tools/pdf/pdf-to-word/page.tsx
@@ -36,8 +36,8 @@ export default function PDFToWordPage() {
     for (let i = 1; i <= pdf.numPages; i++) {
       const page = await pdf.getPage(i);
       const content = await page.getTextContent();
-      const text = content.items
-        .map((item: any) => ("str" in item ? (item as any).str : ""))
+      const text = (content.items as Array<{ str?: string }>)
+        .map((item) => ("str" in item && item.str ? item.str : ""))
         .join(" ");
       paragraphs.push(new Paragraph(text));
       setProgress(Math.round((i / pdf.numPages) * 100));


### PR DESCRIPTION
## Summary
- fix `no-explicit-any` issue in PDF to Word conversion
- switch PDF merge thumbnails to `next/image`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848d12ce114832580ed9d660c36404c