### PR TITLE
Fix build by declaring file-saver module

### DIFF
--- a/file-saver.d.ts
+++ b/file-saver.d.ts
@@ -1,0 +1,1 @@
+declare module 'file-saver';


### PR DESCRIPTION
## Summary
- add a declaration file for `file-saver` to resolve missing type error

## Testing
- `npm run build` *(fails: `next` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68500bf29fbc8325aa50eb2f7c45b8e9