### PR TITLE
Implement text generator AI tool

### DIFF
--- a/app/api/generate-text/route.ts
+++ b/app/api/generate-text/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(req: NextRequest) {
+  const { prompt } = await req.json();
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: "Missing OpenAI API key." },
+      { status: 500 }
+    );
+  }
+
+  try {
+    const openAiRes = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: "gpt-3.5-turbo",
+        messages: [{ role: "user", content: prompt }],
+        temperature: 0.7,
+      }),
+    });
+
+    if (!openAiRes.ok) {
+      const errorText = await openAiRes.text();
+      return NextResponse.json(
+        { error: errorText },
+        { status: openAiRes.status }
+      );
+    }
+
+    const data = await openAiRes.json();
+    const text = data.choices?.[0]?.message?.content ?? "";
+    return NextResponse.json({ text });
+  } catch (e) {
+    return NextResponse.json(
+      { error: "Failed to generate text" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/tools/ai/text-generator/page.tsx
+++ b/app/tools/ai/text-generator/page.tsx
@@ -1,16 +1,70 @@
+"use client";
+
+import { useState } from "react";
 import Link from "next/link";
 import ToolsNav from "../../ToolsNav";
 
 export default function TextGeneratorPage() {
+  const [prompt, setPrompt] = useState("");
+  const [result, setResult] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const generate = async () => {
+    if (!prompt.trim()) return;
+    setLoading(true);
+    setError(null);
+    setResult("");
+    try {
+      const res = await fetch("/api/generate-text", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ prompt }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Error generating text");
+      setResult(data.text);
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
     <div className="bg-gradient-to-b from-black via-gray-900 to-black text-white min-h-screen p-6 sm:p-12">
       <ToolsNav />
-      <div className="max-w-4xl mx-auto text-center">
-        <h1 className="text-3xl sm:text-5xl font-bold mb-8">Text Generator</h1>
-        <p className="text-lg mb-10">This tool will allow you to generate text using AI. Stay tuned!</p>
-        <Link href="/tools/ai" className="text-accent-color hover:underline">
+      <div className="max-w-3xl mx-auto">
+        <Link href="/tools/ai" className="text-accent-color hover:underline text-sm">
           ← Back to AI Tools
         </Link>
+        <h1 className="text-5xl font-extrabold my-6 text-center">Text Generator</h1>
+        <p className="text-center text-gray-400 mb-10">Enter a prompt and generate text using AI.</p>
+        <textarea
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          rows={6}
+          className="w-full p-4 rounded-lg text-black"
+          placeholder="Type your prompt here..."
+        />
+        <div className="text-center mt-6">
+          <button
+            onClick={generate}
+            disabled={loading}
+            className="px-6 py-3 bg-accent-color text-black font-semibold rounded-lg hover:brightness-110 transition disabled:opacity-50"
+          >
+            {loading ? "Generating..." : "Generate Text"}
+          </button>
+        </div>
+        {error && <p className="text-red-400 text-center mt-4">{error}</p>}
+        {result && (
+          <div className="mt-10 bg-gray-900 p-4 rounded-lg border border-gray-700">
+            <h2 className="text-xl font-bold mb-2 text-center">Result</h2>
+            <p className="whitespace-pre-line">{result}</p>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- create `/api/generate-text` API endpoint using OpenAI
- build interactive Text Generator page that calls the API

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850131e6b248325a74b156e0b2c78bc