### PR TITLE
Add contact, about, and privacy pages

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+export default function About() {
+  return (
+    <div className="bg-gradient-to-b from-gray-900 to-black text-white min-h-screen p-6 sm:p-12">
+      <div className="max-w-3xl mx-auto space-y-6">
+        <h1 className="text-3xl sm:text-5xl font-bold text-center">About Digital Meta Zone</h1>
+        <p>
+          Digital Meta Zone curates cutting-edge tools and resources for developers, designers, and tech enthusiasts. Our mission is to provide easy access to utilities that streamline workflows and spark innovation.
+        </p>
+        <p>
+          We experiment with new technologies and share insights through our blog, while offering a growing library of utilities from PDF merging to AI-powered assistants. Our team is passionate about bridging the gap between complex tech and everyday problem solving.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+export default function Contact() {
+  return (
+    <div className="bg-gradient-to-b from-gray-900 to-black text-white min-h-screen p-6 sm:p-12">
+      <div className="max-w-2xl mx-auto">
+        <h1 className="text-3xl sm:text-5xl font-bold text-center mb-6">Contact Us</h1>
+        <p className="text-center mb-8">Have questions or suggestions? Reach out below.</p>
+        <form className="space-y-4" action="mailto:info@digitalmetazone.com" method="post" encType="text/plain">
+          <div className="flex flex-col">
+            <label htmlFor="name" className="mb-1">Name</label>
+            <input type="text" id="name" name="name" className="p-2 rounded text-black" required />
+          </div>
+          <div className="flex flex-col">
+            <label htmlFor="email" className="mb-1">Email</label>
+            <input type="email" id="email" name="email" className="p-2 rounded text-black" required />
+          </div>
+          <div className="flex flex-col">
+            <label htmlFor="message" className="mb-1">Message</label>
+            <textarea id="message" name="message" rows={5} className="p-2 rounded text-black" required />
+          </div>
+          <button type="submit" className="px-6 py-2 bg-accent-color rounded-lg hover:bg-blue-700 transition">Send</button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+export default function Privacy() {
+  return (
+    <div className="bg-gradient-to-b from-gray-900 to-black text-white min-h-screen p-6 sm:p-12">
+      <div className="max-w-3xl mx-auto space-y-6">
+        <h1 className="text-3xl sm:text-5xl font-bold text-center mb-6">Privacy Policy</h1>
+        <p>
+          We respect your privacy. Any information collected through contact forms is used solely to respond to inquiries. We do not sell or share personal data.
+        </p>
+        <p>
+          By using our tools, you acknowledge that no sensitive data is stored on our servers unless explicitly stated. This site uses basic analytics to improve the user experience.
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add an About page describing Digital Meta Zone
- add a Contact page with a simple mail form
- add a Privacy Policy page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68511e6ffb208325806d7ef78025f81d