### PR TITLE
Add AI news page and scraper

### DIFF
--- a/app/data/aiTools.ts
+++ b/app/data/aiTools.ts
@@ -17,4 +17,10 @@ export const aiTools = [
     slug: "chatbot",
     comingSoon: true,
   },
+  {
+    name: "Latest News",
+    description: "Stay updated with trending AI news articles.",
+    slug: "news",
+    comingSoon: false,
+  },
 ];

--- a/app/data/latestNews.json
+++ b/app/data/latestNews.json
@@ -1,0 +1,52 @@
+[
+  {
+    "title": "AI Breakthrough in Computer Vision",
+    "link": "https://example.com/news1",
+    "image": "https://placehold.co/600x400?text=News+1"
+  },
+  {
+    "title": "New ChatGPT Model Released",
+    "link": "https://example.com/news2",
+    "image": "https://placehold.co/600x400?text=News+2"
+  },
+  {
+    "title": "Robotics Advances in 2024",
+    "link": "https://example.com/news3",
+    "image": "https://placehold.co/600x400?text=News+3"
+  },
+  {
+    "title": "Researchers Improve Reinforcement Learning",
+    "link": "https://example.com/news4",
+    "image": "https://placehold.co/600x400?text=News+4"
+  },
+  {
+    "title": "Major Funding for AI Startups",
+    "link": "https://example.com/news5",
+    "image": "https://placehold.co/600x400?text=News+5"
+  },
+  {
+    "title": "AI Ethics Debate Continues",
+    "link": "https://example.com/news6",
+    "image": "https://placehold.co/600x400?text=News+6"
+  },
+  {
+    "title": "New AI Hardware Unveiled",
+    "link": "https://example.com/news7",
+    "image": "https://placehold.co/600x400?text=News+7"
+  },
+  {
+    "title": "Self-driving Cars Reach New Milestone",
+    "link": "https://example.com/news8",
+    "image": "https://placehold.co/600x400?text=News+8"
+  },
+  {
+    "title": "AI Helps Predict Weather Patterns",
+    "link": "https://example.com/news9",
+    "image": "https://placehold.co/600x400?text=News+9"
+  },
+  {
+    "title": "Generative Art Goes Mainstream",
+    "link": "https://example.com/news10",
+    "image": "https://placehold.co/600x400?text=News+10"
+  }
+]

--- a/app/tools/ai/news/page.tsx
+++ b/app/tools/ai/news/page.tsx
@@ -1,0 +1,20 @@
+import ToolsNav from "../../ToolsNav";
+import latestNews from "../../../data/latestNews.json";
+import NewsCard from "../../../../components/NewsCard";
+
+export default function AINewsPage() {
+  return (
+    <div className="bg-gradient-to-b from-gray-900 to-black text-white min-h-screen">
+      <ToolsNav />
+      <div className="max-w-6xl mx-auto p-6 sm:p-12">
+        <h1 className="text-3xl sm:text-5xl font-bold text-center mb-10">Latest News</h1>
+        <div className="section-divider mb-10" />
+        <div className="grid gap-6 sm:grid-cols-2">
+          {latestNews.map((item, idx) => (
+            <NewsCard key={idx} item={item} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/NewsCard.tsx
+++ b/components/NewsCard.tsx
@@ -1,0 +1,28 @@
+import Image from 'next/image';
+
+export interface NewsItem {
+  title: string;
+  link: string;
+  image: string;
+}
+
+export default function NewsCard({ item }: { item: NewsItem }) {
+  return (
+    <a
+      href={item.link}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="service-card transition-transform hover:scale-105 flex flex-col"
+    >
+      <div className="relative w-full h-40 mb-4">
+        <Image
+          src={item.image}
+          alt={item.title}
+          fill
+          className="object-cover rounded"
+        />
+      </div>
+      <h3 className="text-lg font-semibold text-center">{item.title}</h3>
+    </a>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "update-news": "node scripts/updateNews.js"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -20,7 +21,8 @@
     "pdfjs-dist": "^3.4.120",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "three": "^0.171.0"
+    "three": "^0.171.0",
+    "rss-parser": "^3.12.0"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/scripts/updateNews.js
+++ b/scripts/updateNews.js
@@ -1,0 +1,25 @@
+import fs from 'fs/promises';
+import Parser from 'rss-parser';
+
+const parser = new Parser();
+const RSS_URL = 'https://hnrss.org/frontpage';
+
+async function fetchNews() {
+  const feed = await parser.parseURL(RSS_URL);
+  return feed.items.slice(0, 10).map((item, idx) => ({
+    title: item.title || `News ${idx + 1}`,
+    link: item.link || '',
+    image: item.enclosure?.url || 'https://placehold.co/600x400?text=News'
+  }));
+}
+
+async function update() {
+  const news = await fetchNews();
+  await fs.writeFile('./app/data/latestNews.json', JSON.stringify(news, null, 2));
+  console.log('Latest news updated');
+}
+
+update().catch(err => {
+  console.error('Failed to update news', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add latest news page under AI tools
- provide `NewsCard` component
- store sample news in `latestNews.json`
- update AI tools list with news link
- add script `updateNews.js` and NPM script `update-news`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a9b449d408325b67e298902b2ea7a