### PR TITLE
Stub canvas dependency to fix PDF tool builds

### DIFF
--- a/app/tools/pdf/merge/page.tsx
+++ b/app/tools/pdf/merge/page.tsx
@@ -20,7 +20,10 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 
-import * as pdfjsLib from "pdfjs-dist";
+// Use the webpack-friendly build of pdfjs to avoid the optional Node
+// `canvas` dependency that causes Next.js builds to fail. This build is
+// meant for browser environments and works seamlessly in production.
+import * as pdfjsLib from "pdfjs-dist/webpack";
 pdfjsLib.GlobalWorkerOptions.workerSrc =
   "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.4.120/pdf.worker.min.js";
 

--- a/app/tools/pdf/pdf-to-word/page.tsx
+++ b/app/tools/pdf/pdf-to-word/page.tsx
@@ -4,7 +4,11 @@ import { useState } from "react";
 import Link from "next/link";
 import { Document, Packer, Paragraph } from "docx";
 import { saveAs } from "file-saver";
-import * as pdfjsLib from "pdfjs-dist";
+// Importing the webpack build of pdfjs prevents Next.js from trying to
+// include the optional Node `canvas` package during build time, which
+// previously caused compilation errors. This variant is intended for
+// bundlers and works entirely in the browser.
+import * as pdfjsLib from "pdfjs-dist/webpack";
 
 pdfjsLib.GlobalWorkerOptions.workerSrc =
   "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.4.120/pdf.worker.min.js";

--- a/app/tools/pdf/split/page.tsx
+++ b/app/tools/pdf/split/page.tsx
@@ -2,7 +2,12 @@
 
 import { useRef, useState } from "react";
 import { PDFDocument } from "pdf-lib";
-import * as pdfjsLib from "pdfjs-dist";
+// Use the special webpack build of pdfjs to avoid pulling in the Node
+// `canvas` dependency during Next.js server-side builds. The default
+// entry attempts to require `canvas` which causes the build to fail.
+// Importing from `pdfjs-dist/webpack` provides a browser-friendly
+// bundle that works both in development and production.
+import * as pdfjsLib from "pdfjs-dist/webpack";
 import Link from "next/link";
 import Image from "next/image";
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,22 @@
 import type { NextConfig } from "next";
 
+// Next.js configuration. In addition to setting the optional base path we
+// also tweak the webpack configuration so that the optional `canvas`
+// dependency used by `pdfjs-dist` is stubbed out. The pdf.js library checks
+// for this module when running in Node environments, but our application only
+// uses it in the browser. Without this alias Next.js would fail to compile
+// because it tries to bundle the native `canvas` package.
 const nextConfig: NextConfig = {
   basePath: process.env.NEXT_PUBLIC_BASE_PATH || "",
+  webpack: (config) => {
+    // Prevent webpack from attempting to bundle the native `canvas` module.
+    config.resolve = config.resolve || {};
+    config.resolve.alias = {
+      ...(config.resolve.alias || {}),
+      canvas: false,
+    };
+    return config;
+  },
 };
 
 export default nextConfig;

--- a/pdfjs-dist.d.ts
+++ b/pdfjs-dist.d.ts
@@ -1,0 +1,1 @@
+declare module 'pdfjs-dist/webpack';


### PR DESCRIPTION
## Summary
- use `pdfjs-dist/webpack` in PDF tools to avoid pulling in native `canvas`
- alias `canvas` to `false` in Next.js webpack config
- add TypeScript declarations for the pdfjs webpack entry

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68971c69c0708325ba14882d428dfcff